### PR TITLE
Resolve make error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ description = """"""
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
     
-long_description = read('README.rst')
+long_description = read('README.md')
     
 
 setup(name='ConfTools',


### PR DESCRIPTION
When installing using `python setup.py develop`, you would get an error saying that `README.rst` cannot be found. So I updated the program to look for `README.md`. This seems like a bit of a weak fix. Maybe change the `read()` call so that if it can't find the file, it doesn't crash?
